### PR TITLE
feat: 引入FileSaveHelper并为PhotoDialog添加长按保存

### DIFF
--- a/app/src/main/java/io/legado/app/help/FileSaveHelper.kt
+++ b/app/src/main/java/io/legado/app/help/FileSaveHelper.kt
@@ -1,0 +1,105 @@
+package io.legado.app.help
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import androidx.documentfile.provider.DocumentFile
+import io.legado.app.help.DirectLinkUpload
+import io.legado.app.utils.DocumentUtils
+import io.legado.app.utils.FileUtils
+import io.legado.app.utils.GSON
+import io.legado.app.utils.isContentScheme
+import io.legado.app.utils.writeBytes
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+
+object FileSaveHelper {
+
+    fun saveFile(
+        context: Context,
+        uri: Uri,
+        fileName: String,
+        data: Any
+    ): Uri {
+        val bytes = when (data) {
+            is File -> data.readBytes()
+            is ByteArray -> data
+            is String -> data.toByteArray()
+            is Bitmap -> {
+                val stream = ByteArrayOutputStream()
+                data.compress(Bitmap.CompressFormat.PNG, 100, stream)
+                stream.toByteArray()
+            }
+            else -> GSON.toJson(data).toByteArray()
+        }
+        return if (uri.isContentScheme()) {
+            val doc = DocumentFile.fromTreeUri(context, uri)!!
+            doc.findFile(fileName)?.delete()
+            val newDoc = doc.createFile("", fileName)
+            newDoc!!.writeBytes(context, bytes)
+            newDoc.uri
+        } else {
+            val file = File(uri.path ?: uri.toString())
+            val newFile = FileUtils.createFileIfNotExist(file, fileName)
+            newFile.writeBytes(bytes)
+            Uri.fromFile(newFile)
+        }
+    }
+
+    fun saveFileFromStream(
+        context: Context,
+        uri: Uri,
+        fileName: String,
+        input: FileInputStream
+    ): Uri {
+        return if (uri.isContentScheme()) {
+            DocumentFile.fromTreeUri(context, uri)?.let { doc ->
+                val imageDoc = DocumentUtils.createFileIfNotExist(doc, fileName)!!
+                context.contentResolver.openOutputStream(imageDoc.uri)!!.use { output ->
+                    input.copyTo(output)
+                }
+                imageDoc.uri
+            } ?: throw Exception("Failed to get DocumentFile from URI")
+        } else {
+            val dir = File(uri.path ?: uri.toString())
+            val file = FileUtils.createFileIfNotExist(dir, fileName)
+            FileOutputStream(file).use { output ->
+                input.copyTo(output)
+            }
+            Uri.fromFile(file)
+        }
+    }
+
+    suspend fun uploadFile(
+        fileName: String,
+        file: Any,
+        contentType: String
+    ): String {
+        return DirectLinkUpload.upLoad(fileName, file, contentType)
+    }
+
+    suspend fun saveAndUpload(
+        context: Context,
+        saveUri: Uri?,
+        fileName: String,
+        data: Any,
+        contentType: String,
+        upload: Boolean = false
+    ): Pair<Uri?, String?> {
+        var savedUri: Uri? = null
+        var uploadedUrl: String? = null
+
+        if (saveUri != null) {
+            savedUri = saveFile(context, saveUri, fileName, data)
+        }
+
+        if (upload) {
+            uploadedUrl = uploadFile(fileName, data, contentType)
+        }
+
+        return Pair(savedUri, uploadedUrl)
+    }
+
+}

--- a/app/src/main/java/io/legado/app/ui/book/manga/ReadMangaViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/book/manga/ReadMangaViewModel.kt
@@ -25,9 +25,7 @@ import io.legado.app.help.config.AppConfig
 import io.legado.app.help.coroutine.Coroutine
 import io.legado.app.model.ReadManga
 import io.legado.app.model.webBook.WebBook
-import io.legado.app.utils.DocumentUtils
-import io.legado.app.utils.FileUtils
-import io.legado.app.utils.isContentScheme
+import io.legado.app.help.FileSaveHelper
 import io.legado.app.utils.mapParallelSafe
 import io.legado.app.utils.postEvent
 import io.legado.app.utils.toastOnUi
@@ -42,7 +40,6 @@ import kotlinx.coroutines.flow.take
 import splitties.init.appCtx
 import java.io.File
 import java.io.FileInputStream
-import java.io.FileOutputStream
 
 class ReadMangaViewModel(application: Application) : BaseViewModel(application) {
 
@@ -237,20 +234,7 @@ class ReadMangaViewModel(application: Application) : BaseViewModel(application) 
         execute {
             val image = BookHelp.getImage(book, src)
             FileInputStream(image).use { input ->
-                if (uri.isContentScheme()) {
-                    DocumentFile.fromTreeUri(context, uri)?.let { doc ->
-                        val imageDoc = DocumentUtils.createFileIfNotExist(doc, image.name)!!
-                        context.contentResolver.openOutputStream(imageDoc.uri)!!.use { output ->
-                            input.copyTo(output)
-                        }
-                    }
-                } else {
-                    val dir = File(uri.path ?: uri.toString())
-                    val file = FileUtils.createFileIfNotExist(dir, image.name)
-                    FileOutputStream(file).use { output ->
-                        input.copyTo(output)
-                    }
-                }
+                FileSaveHelper.saveFileFromStream(context, uri, image.name, input)
             }
             appCtx.toastOnUi("已保存图片")
         }.onError {

--- a/app/src/main/java/io/legado/app/ui/file/HandleFileViewModel.kt
+++ b/app/src/main/java/io/legado/app/ui/file/HandleFileViewModel.kt
@@ -2,17 +2,11 @@ package io.legado.app.ui.file
 
 import android.app.Application
 import android.net.Uri
-import androidx.documentfile.provider.DocumentFile
 import androidx.lifecycle.MutableLiveData
 import io.legado.app.base.BaseViewModel
 import io.legado.app.constant.AppLog
-import io.legado.app.help.DirectLinkUpload
-import io.legado.app.utils.FileUtils
-import io.legado.app.utils.GSON
-import io.legado.app.utils.isContentScheme
+import io.legado.app.help.FileSaveHelper
 import io.legado.app.utils.printOnDebug
-import io.legado.app.utils.writeBytes
-import java.io.File
 
 class HandleFileViewModel(application: Application) : BaseViewModel(application) {
 
@@ -25,7 +19,7 @@ class HandleFileViewModel(application: Application) : BaseViewModel(application)
         success: (url: String) -> Unit
     ) {
         execute {
-            DirectLinkUpload.upLoad(fileName, file, contentType)
+            FileSaveHelper.uploadFile(fileName, file, contentType)
         }.onSuccess {
             success.invoke(it)
         }.onError {
@@ -37,24 +31,7 @@ class HandleFileViewModel(application: Application) : BaseViewModel(application)
 
     fun saveToLocal(uri: Uri, fileName: String, data: Any, success: (uri: Uri) -> Unit) {
         execute {
-            val bytes = when (data) {
-                is File -> data.readBytes()
-                is ByteArray -> data
-                is String -> data.toByteArray()
-                else -> GSON.toJson(data).toByteArray()
-            }
-            return@execute if (uri.isContentScheme()) {
-                val doc = DocumentFile.fromTreeUri(context, uri)!!
-                doc.findFile(fileName)?.delete()
-                val newDoc = doc.createFile("", fileName)
-                newDoc!!.writeBytes(context, bytes)
-                newDoc.uri
-            } else {
-                val file = File(uri.path ?: uri.toString())
-                val newFile = FileUtils.createFileIfNotExist(file, fileName)
-                newFile.writeBytes(bytes)
-                Uri.fromFile(newFile)
-            }
+            FileSaveHelper.saveFile(context, uri, fileName, data)
         }.onError {
             it.printOnDebug()
             errorLiveData.postValue(it.localizedMessage)

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
@@ -4,21 +4,28 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.net.toUri
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy
 import com.bumptech.glide.request.RequestOptions
 import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
+import io.legado.app.constant.AppConst.imagePathKey
 import io.legado.app.databinding.DialogPhotoViewBinding
 import io.legado.app.help.book.BookHelp
 import io.legado.app.help.glide.ImageLoader
 import io.legado.app.help.glide.OkHttpModelLoader
+import io.legado.app.lib.dialogs.SelectItem
 import io.legado.app.model.BookCover
 import io.legado.app.model.ImageProvider
 import io.legado.app.model.ReadBook
+import io.legado.app.ui.file.HandleFileContract
+import io.legado.app.utils.ACache
 import io.legado.app.utils.setLayout
+import io.legado.app.utils.toast
 import io.legado.app.utils.viewbindingdelegate.viewBinding
+import kotlinx.coroutines.launch
 
 /**
  * 显示图片
@@ -33,6 +40,13 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
     }
 
     private val binding by viewBinding(DialogPhotoViewBinding::bind)
+    private var imageSrc: String? = null
+    private val saveImage = registerForActivityResult(HandleFileContract()) {
+        it.uri?.let { uri ->
+            ACache.get().put(imagePathKey, uri.toString())
+            saveImage(imageSrc, uri)
+        }
+    }
 
     override fun onStart() {
         super.onStart()
@@ -43,8 +57,10 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
     override fun onFragmentCreated(view: View, savedInstanceState: Bundle?) {
         val arguments = arguments ?: return
         val src = arguments.getString("src") ?: return
+        imageSrc = src
         ImageProvider.get(src)?.let {
             binding.photoView.setImageBitmap(it)
+            setLongClick()
             return
         }
         val file = ReadBook.book?.let { book ->
@@ -66,6 +82,55 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
                 .dontTransform()
                 .downsample(DownsampleStrategy.NONE)
                 .into(binding.photoView)
+        }
+        setLongClick()
+    }
+
+    private fun setLongClick() {
+        binding.photoView.setOnLongClickListener {
+            saveImage(imageSrc)
+            true
+        }
+    }
+
+    private fun saveImage(url: String?) {
+        url?.let {
+            this.imageSrc = it
+            val path = ACache.get().getAsString(imagePathKey)
+            if (path.isNullOrEmpty()) {
+                selectSaveFolder(it)
+            } else {
+                saveImage(it, path.toUri())
+            }
+        }
+    }
+
+    private fun selectSaveFolder(url: String) {
+        this.imageSrc = url
+        val default = arrayListOf<SelectItem<Int>>()
+        val path = ACache.get().getAsString(imagePathKey)
+        if (!path.isNullOrEmpty()) {
+            default.add(SelectItem(path, -1))
+        }
+        saveImage.launch {
+            otherActions = default
+        }
+    }
+
+    private fun saveImage(url: String?, uri: android.net.Uri) {
+        url?.let {
+            lifecycleScope.launch {
+                kotlin.runCatching {
+                    val bitmap = ImageProvider.get(it) ?: return@launch
+                    val outputStream = requireContext().contentResolver.openOutputStream(uri)
+                    outputStream?.use {out ->
+                        bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)
+                    }
+                    toast(R.string.save_success)
+                }.onFailure {
+                    toast(R.string.save_fail)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
@@ -25,7 +25,7 @@ import io.legado.app.ui.file.HandleFileContract
 import io.legado.app.utils.ACache
 import androidx.lifecycle.lifecycleScope
 import io.legado.app.utils.setLayout
-import io.legado.app.utils.toast
+import io.legado.app.utils.toastOnUi
 import io.legado.app.utils.viewbindingdelegate.viewBinding
 
 /**
@@ -114,6 +114,7 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
             default.add(SelectItem(path, -1))
         }
         saveImage.launch {
+            mode = HandleFileContract.DIR
             otherActions = default
         }
     }
@@ -125,9 +126,9 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
                     val bitmap = ImageProvider.get(it) ?: return@launch
                     val fileName = "image_${System.currentTimeMillis()}.png"
                     FileSaveHelper.saveFile(requireContext(), uri, fileName, bitmap)
-                    toast(R.string.save_success)
+                    toastOnUi("已保存图片")
                 }.onFailure {
-                    toast(R.string.save_fail)
+                    toastOnUi("保存图片出错\n${it.localizedMessage}")
                 }
             }
         }

--- a/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
+++ b/app/src/main/java/io/legado/app/ui/widget/dialog/PhotoDialog.kt
@@ -13,6 +13,7 @@ import io.legado.app.R
 import io.legado.app.base.BaseDialogFragment
 import io.legado.app.constant.AppConst.imagePathKey
 import io.legado.app.databinding.DialogPhotoViewBinding
+import io.legado.app.help.FileSaveHelper
 import io.legado.app.help.book.BookHelp
 import io.legado.app.help.glide.ImageLoader
 import io.legado.app.help.glide.OkHttpModelLoader
@@ -22,10 +23,10 @@ import io.legado.app.model.ImageProvider
 import io.legado.app.model.ReadBook
 import io.legado.app.ui.file.HandleFileContract
 import io.legado.app.utils.ACache
+import androidx.lifecycle.lifecycleScope
 import io.legado.app.utils.setLayout
 import io.legado.app.utils.toast
 import io.legado.app.utils.viewbindingdelegate.viewBinding
-import kotlinx.coroutines.launch
 
 /**
  * 显示图片
@@ -122,10 +123,8 @@ class PhotoDialog() : BaseDialogFragment(R.layout.dialog_photo_view) {
             lifecycleScope.launch {
                 kotlin.runCatching {
                     val bitmap = ImageProvider.get(it) ?: return@launch
-                    val outputStream = requireContext().contentResolver.openOutputStream(uri)
-                    outputStream?.use {out ->
-                        bitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, out)
-                    }
+                    val fileName = "image_${System.currentTimeMillis()}.png"
+                    FileSaveHelper.saveFile(requireContext(), uri, fileName, bitmap)
                     toast(R.string.save_success)
                 }.onFailure {
                     toast(R.string.save_fail)


### PR DESCRIPTION
## 🎯 Changes

### 1. 新增 `FileSaveHelper` 工具类
- 统一文件保存和上传功能，支持多种数据类型（File、ByteArray、String、Bitmap等）。
- 提供 `saveFile`、`saveFileFromStream`、`uploadFile`、`saveAndUpload` 等方法。
- 支持保存到 `ContentScheme` 和普通文件路径。

### 2. `ReadMangaViewModel` 优化
- 引入 `FileSaveHelper` 替代原有文件保存逻辑。
- 简化图片保存代码，使用 `FileSaveHelper.saveFileFromStream` 方法。

### 3. `HandleFileViewModel` 优化
- 引入 `FileSaveHelper` 替代原有文件保存和上传逻辑。
- 简化 `upload` 方法，使用 `FileSaveHelper.uploadFile`。
- 简化 `saveToLocal` 方法，使用 `FileSaveHelper.saveFile`。

### 4. `PhotoDialog` 新增功能
- 为图片添加长按保存功能。
- 引入 `FileSaveHelper` 来处理图片保存。
- 增加保存路径选择和缓存功能，提升用户体验。

## 💡 Technical Highlights

- **代码复用**: 通过引入 `FileSaveHelper`，统一了文件操作逻辑，减少了各模块的重复代码。
- **灵活性**: `FileSaveHelper` 支持多种数据源和保存目标，提高了文件处理的灵活性。
- **用户体验**: `PhotoDialog` 的长按保存功能，为用户提供了更便捷的图片保存方式。