### PR TITLE
refactor: 统一 ImageLoader 的 Glide 缓存策略为 DiskCacheStrategy.DATA

### DIFF
--- a/app/src/main/java/io/legado/app/help/glide/ImageLoader.kt
+++ b/app/src/main/java/io/legado/app/help/glide/ImageLoader.kt
@@ -83,7 +83,7 @@ object ImageLoader {
         return load(context, path)
             .apply(options)
             .override(context.resources.displayMetrics.widthPixels, SIZE_ORIGINAL)
-            .diskCacheStrategy(DiskCacheStrategy.ALL)
+            .diskCacheStrategy(DiskCacheStrategy.DATA)
             .skipMemoryCache(true).let {
                 if (transformation != null) {
                     it.transform(transformation)

--- a/app/src/main/java/io/legado/app/help/glide/ImageLoader.kt
+++ b/app/src/main/java/io/legado/app/help/glide/ImageLoader.kt
@@ -37,6 +37,7 @@ object ImageLoader {
         inBookshelf: Boolean = false
     ): RequestBuilder<Drawable> {
         return requestManager.load(if (path.isFilePath()) File(path) else path)
+            .diskCacheStrategy(DiskCacheStrategy.DATA)
             .let { if (inBookshelf) it.signature(ObjectKey("covers")) else it }
     }
 
@@ -62,7 +63,7 @@ object ImageLoader {
         return when {
             path.isFilePath() -> requestManager.load(File(path))
             else -> requestManager.load(path)
-        }
+        }.diskCacheStrategy(DiskCacheStrategy.DATA)
     }
 
     /**


### PR DESCRIPTION
## 🎯 Changes

### 1. ImageLoader 缓存策略统一
- 在 `ImageLoader.kt` 的第一个 `load` 函数中，新增 `diskCacheStrategy(DiskCacheStrategy.DATA)` 设置。
- 在 `ImageLoader.kt` 的第二个 `load` 函数重载中，新增 `diskCacheStrategy(DiskCacheStrategy.DATA)` 设置。
- 在 `ImageLoader.kt` 的第三个 `load` 函数中，将缓存策略从 `DiskCacheStrategy.ALL` 更改为 `DiskCacheStrategy.DATA`。

## 💡 Technical Highlights

- **缓存策略统一**: 将所有图片加载方法的 Glide 磁盘缓存策略统一为 `DiskCacheStrategy.DATA`，确保缓存行为一致性。
- **优化磁盘使用**: `DiskCacheStrategy.DATA` 仅缓存原始图片数据，有助于减少磁盘占用并提高缓存效率。