### PR TITLE
perf: 优化 ExploreShowActivity 数据加载性能

### DIFF
--- a/app/src/main/java/io/legado/app/ui/book/explore/ExploreShowActivity.kt
+++ b/app/src/main/java/io/legado/app/ui/book/explore/ExploreShowActivity.kt
@@ -229,12 +229,14 @@ class ExploreShowActivity : VMBaseActivity<ActivityExploreShowBinding, ExploreSh
 
     private fun upData(books: List<SearchBook>) {
         loadMoreView.stopLoad()
-        if (books.isEmpty() && adapter.isEmpty()) {
+        val oldSize = adapter.getActualItemCount()
+        if (books.isEmpty() && oldSize == 0) {
             loadMoreView.noMore(getString(R.string.empty))
-        } else if (adapter.getActualItemCount() >= books.size && viewModel.page > 1) {
+        } else if (oldSize >= books.size && viewModel.page > 1) {
             loadMoreView.noMore()
-        } else {
-            adapter.setItems(books)
+        } else if (oldSize < books.size) {
+            val newItems = books.subList(oldSize, books.size)
+            adapter.addItems(newItems)
         }
     }
 


### PR DESCRIPTION
## 🎯 Changes

### 1. ExploreShowActivity 数据加载优化
- 缓存适配器项目数量到 `oldSize` 变量，避免重复调用 `getActualItemCount()`。
- 将数据更新逻辑从全量设置 `setItems()` 改为增量添加 `addItems()`，仅添加新增的项目。
- 优化空数据判断条件，使用缓存值替代直接方法调用。

## 💡 Technical Highlights

- **性能提升**: 通过增量更新和缓存，减少了不必要的数据操作和方法调用，提升了数据加载效率。
- **资源优化**: 避免了在每次数据更新时重新创建或重新绑定所有视图，降低了资源消耗。