### PR TITLE
fix(ios): prevent startup crash from Compose plist sanity check

### DIFF
--- a/iosApp/Info.plist
+++ b/iosApp/Info.plist
@@ -31,6 +31,9 @@
     <false/>
     <key>UIViewControllerBasedStatusBarAppearance</key>
     <true/>
+    <!-- Compose Multiplatform 1.11+ 启动必需；同时解除 ProMotion 设备的 60Hz 帧率限制。 -->
+    <key>CADisableMinimumFrameDurationOnPhone</key>
+    <true/>
 
     <!-- 屏幕方向: legado 是阅读类 App, 支持竖屏 + 横屏 + 翻转 -->
     <key>UISupportedInterfaceOrientations</key>

--- a/iosApp/project.yml
+++ b/iosApp/project.yml
@@ -54,6 +54,8 @@ targets:
         UIStatusBarStyle: UIStatusBarStyleDefault
         UIStatusBarHidden: false
         UIViewControllerBasedStatusBarAppearance: true
+        # Compose Multiplatform 1.11+ 启动时强制校验；缺失或为 false 会直接抛异常终止进程。
+        CADisableMinimumFrameDurationOnPhone: true
         # 屏幕方向: 阅读类 App, 竖屏 + 横屏
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## 问题

iOS Release IPA 启动约 3 秒后触发 `SIGABRT`。真机 `.ips` 的 `lastExceptionBacktrace` 指向 `androidx.compose.ui.uikit.PlistSanityCheck.performIfNeeded`。

Compose Multiplatform 1.11.x 会强制要求主 Bundle 的 `Info.plist` 包含：

```xml
<key>CADisableMinimumFrameDurationOnPhone</key>
<true/>
```

缺失或为 `false` 时会调用 `error()`，Kotlin/Native 未捕获异常最终终止进程。

## 修复

- 在 `iosApp/project.yml` 的 XcodeGen properties 中加入该键。
- 在 `iosApp/Info.plist` 同步加入该键，保持仓库约定的双写一致性。

## 验证

- `plutil -lint iosApp/Info.plist` 通过。
- `CADisableMinimumFrameDurationOnPhone` 解析结果为 `true`。
- `./gradlew :shared:linkReleaseFrameworkIosArm64`：`BUILD SUCCESSFUL`。
- `xcodebuild archive`：`ARCHIVE SUCCEEDED`。
- 解包生成的未签名 IPA 后再次确认最终 App Bundle 中该键为 `true`，主程序与 `shared.framework` 均为 arm64 Mach-O。